### PR TITLE
Time since last system upgrade feature.

### DIFF
--- a/archey3
+++ b/archey3
@@ -18,6 +18,7 @@ from optparse import OptionParser
 from getpass import getuser
 from time import ctime, sleep
 from os import getenv
+from datetime import datetime
 import re
 import os.path
 import multiprocessing
@@ -508,6 +509,34 @@ class mpdDisplay(display):
 
         return ('{statname} in MPD database'.format(statname=self.stat.title()),
                stats[self.stat])
+
+@module_register("system_upgrade")
+class systemUpgrade(display):
+
+    _upgrade_message = 'starting full system upgrade'
+
+    def render(self):
+        try:
+            datestr = None
+            for line in reversed(list(open('/var/log/pacman.log'))):
+                if line.rstrip().endswith(self._upgrade_message):
+                    datestart = line.find('[')
+                    dateend = line.find(']')
+                    if datestart != -1 and dateend != -1:
+                        datestr = line[datestart + 1 : dateend]
+                    break
+        except Exception as err:
+            print(err)
+
+        if not datestr:
+            datestr = 'Unknown'
+        else:
+            currenttime = datetime.today()
+            updatetime = datetime.strptime(datestr, '%Y-%m-%d %H:%M')
+            numdays = (currenttime - updatetime).days
+            datestr = '{0} ({1} days ago)'.format(datestr, numdays)
+
+        return "Last Upgrade", datestr
 
 #------------ Config    -----------
 


### PR DESCRIPTION
Reads pacman's log file and finds the time of the last full system upgrade. Helps me to keep my system from getting stale.

To enable the feature you'll need to add system_upgrade() to your config file.

![screenshot from 2013-05-10 00 00 41](https://f.cloud.github.com/assets/1390340/482629/d53ecb66-b89f-11e2-80ec-3582a2779699.png)
