### PR TITLE
Fix overreported installed package count.

### DIFF
--- a/archey3
+++ b/archey3
@@ -415,7 +415,7 @@ class packageDisplay(display):
     command_line = "pacman -Q"
 
     def format_output(self, instring):
-        return "Packages", len(instring.split('\n'))
+        return "Packages", len(instring.rstrip('\n').split('\n'))
 
 @module_register("distro")
 class distroCheck(display):


### PR DESCRIPTION
Currently the 'Packages' statistic is one higher than it ought to be because of a trailing newline; compare it with `pacman -Q | wc -l`. This is a simple fix.
