### PR TITLE
changed format_output(...) to remove unnecessary quotation marks

### DIFF
--- a/archey3
+++ b/archey3
@@ -239,7 +239,7 @@ class fsDisplay(display):
     def format_output(self, instring):
         try:
             decimal_point = self.call_command(
-                'locale -ck decimal_point').split('\n')[1].split('=')[1]
+                'locale -ck decimal_point').split('\n')[1].split('=')[1].strip('\"')
         except Exception as e:
             self.state.logger.warning('Could not determine locale decimal point,' +
                    'defaulting to \'.\', failed with error {0}'.format(e))


### PR DESCRIPTION
Maybe a solution for #3 
As I'm using "de_DE.UTF-8" locale:

% locale -ck decimal_point
LC_NUMERIC
decimal_point=","

So the problem is, that line 241 gives a comma with quotation marks, but the desired outcome is a comma without them - so I just strip them.
