### PR TITLE
fix issue #27: can now detect kwin in Plasma 5

### DIFF
--- a/archey3
+++ b/archey3
@@ -102,7 +102,7 @@ WM_DICT = collections.OrderedDict([
         ('herbstluftwm', 'herbstluftwm'),
         ('i3', 'i3'),
         ('icewm', 'IceWM'),
-        ('kwin', 'KWin'),
+        (re.compile('kwin(_x11|_wayland)?'), 'KWin'),
         ('metacity', 'Metacity'),
         ('musca', 'Musca'),
         ('openbox', 'Openbox'),


### PR DESCRIPTION
In plasma 5, kwin was renamed kwin_x11 and kwin_wayland, which were not picked up by archey. Added a regex to fix that.