### PR TITLE
Search environment for python3

### DIFF
--- a/archey3
+++ b/archey3
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # archey3
 #


### PR DESCRIPTION
Explicitly look for python3.

Fixes archey3 on systems where python2 is default.
