### PR TITLE
Make archey3 recognize a running GNOME desktop

### DIFF
--- a/archey3
+++ b/archey3
@@ -84,6 +84,7 @@ def module_register(name):
 
 DE_DICT = collections.OrderedDict([
         ('cinnamon', 'Cinnamon'),
+        ('gnome-session', 'GNOME'),
         ('gnome-shell', 'GNOME'),
         ('ksmserver', 'KDE'),
         ('mate-session', 'MATE'),

--- a/archey3
+++ b/archey3
@@ -84,7 +84,7 @@ def module_register(name):
 
 DE_DICT = collections.OrderedDict([
         ('cinnamon', 'Cinnamon'),
-        ('gnome-session', 'GNOME'),
+        ('gnome-shell', 'GNOME'),
         ('ksmserver', 'KDE'),
         ('mate-session', 'MATE'),
         ('xfce4-session', 'Xfce'),


### PR DESCRIPTION
archey3 doesn't recognize that GNOME 3.20 is running. That's because there's no process called `gnome-session`. A safer way to see if GNOME is running would be to look for processes called `gnome-shell`.