### PR TITLE
fix: SafeConfigParser renamed to ConfigParser

### DIFF
--- a/archey3
+++ b/archey3
@@ -802,7 +802,6 @@ class Archey(object):
                 args = ()
 
             yield groups["func"], args
-        raise StopIteration
 
     def format_item(self, item):
         title = item[0].rstrip(':')

--- a/archey3
+++ b/archey3
@@ -548,7 +548,7 @@ class systemUpgrade(display):
 
 #------------ Config    -----------
 
-class ArcheyConfigParser(configparser.SafeConfigParser):
+class ArcheyConfigParser(configparser.ConfigParser):
     """
     A parser for the archey config file.
     """


### PR DESCRIPTION
after latest system update this error has popped up:
```
archey3:862: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = ArcheyConfigParser()
Traceback (most recent call last):
  File "/usr/bin/archey3", line 805, in parse_display
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/archey3", line 869, in <module>
    main()
  File "/usr/bin/archey3", line 866, in main
    archey.run(options.screenshot)
  File "/usr/bin/archey3", line 728, in run
    print(self.render())
  File "/usr/bin/archey3", line 734, in render
    results = self.prepare_results()
  File "/usr/bin/archey3", line 753, in prepare_results
    for cls_name, args in self.parse_display():
RuntimeError: generator raised StopIteration
```